### PR TITLE
商品編集ページ閲覧時のブランド入力済

### DIFF
--- a/app/assets/javascripts/new_item.js
+++ b/app/assets/javascripts/new_item.js
@@ -477,6 +477,8 @@ $(document).on("turbolinks:load",function() {
       if (gon.item.size != null){
         $("#item_size").val(gon.item.size)
       }
+      $("#input_brand_box").val(gon.brand.name);
+      $("#item_brand_id").val(gon.brand.id);
       $("#item_condition").val(gon.item.condition);
       $("#item_shipping_date").val(gon.item.shipping_date)
     }

--- a/app/assets/stylesheets/_new-item.scss
+++ b/app/assets/stylesheets/_new-item.scss
@@ -157,6 +157,12 @@ h2 {
   vertical-align: top;
 }
 
+.attention {
+  line-height: 1.5;
+  margin: 0 0 0 10px;
+  color: #ea352d;
+}
+
 .input-default {
   height: 48px;
   padding: 10px 16px 8px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,9 +28,12 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    @brand = Brand.find(@item.brand_id)
     @parents = Category.all.order("id ASC").limit(13)
     @postages = Postage.all.order("id ASC").limit(2)
     gon.item = @item
+    gon.brand = @brand
+    gon.category = @category
     img_array = []
     @item.images.each do |image|
       img_array.push(image)

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -128,6 +128,8 @@
                   ブランド名
                   %span.form-arbitrary
                     任意
+                  %span.attention
+                    ※ 検索候補から選択してください
                 %div
                   = f.text_field :hoge_id, placeholder: "例）シャネル", class: "input-default", id: "input_brand_box", name: "brand_name"
                   = f.hidden_field :brand_id

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -64,6 +64,8 @@
                   ブランド名
                   %span.form-arbitrary
                     任意
+                  %span.attention
+                    ※ 検索候補から選択してください
                 %div
                   = f.text_field :hoge_id, placeholder: "例）シャネル", class: "input-default", id: "input_brand_box", name: "brand_name"
                   = f.hidden_field :brand_id

--- a/config/database.yml
+++ b/config/database.yml
@@ -47,7 +47,7 @@ development:
 #
 production:
   <<: *default
-  database: freemarket_sample_58a_production
+  database: mercari_sample_production
   username: root
   password: <%= ENV['DATABASE_PASSWORD'] %>
   socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
## What
商品編集ページを開いた時にブランド名が登録されていた場合フォームに入力されている状態になる

## Why
ブランドを変更しない場合でも入力し直さないといけない煩わしさの解消のため